### PR TITLE
feat: Add QR scanner icons to address input fields

### DIFF
--- a/templates/boltz/_reverseSubmarineSwapDialog.html
+++ b/templates/boltz/_reverseSubmarineSwapDialog.html
@@ -69,7 +69,17 @@
         type="string"
         v-if="reverseSubmarineSwapDialog.data.asset"
         :label="reverseSubmarineSwapDialog.data.asset.split('/')[0] + ' onchain address to receive funds'"
-      ></q-input>
+      >
+        <template v-slot:append>
+          <q-icon
+            name="qr_code_scanner"
+            @click="showCameraForField('reverse_onchain')"
+            class="cursor-pointer"
+          >
+            <q-tooltip>Scan QR code</q-tooltip>
+          </q-icon>
+        </template>
+      </q-input>
       <div class="row q-mt-lg">
         <q-btn
           v-if="reverseSubmarineSwapDialog.data.id"

--- a/templates/boltz/_submarineSwapDialog.html
+++ b/templates/boltz/_submarineSwapDialog.html
@@ -55,7 +55,17 @@
         type="string"
         v-if="submarineSwapDialog.data.asset"
         :label="submarineSwapDialog.data.asset.split('/')[0] + ' onchain address to receive funds if swap fails'"
-      ></q-input>
+      >
+        <template v-slot:append>
+          <q-icon
+            name="qr_code_scanner"
+            @click="showCameraForField('submarine_refund')"
+            class="cursor-pointer"
+          >
+            <q-tooltip>Scan QR code</q-tooltip>
+          </q-icon>
+        </template>
+      </q-input>
       <div class="row q-mt-lg">
         <q-btn
           v-if="submarineSwapDialog.data.id"

--- a/templates/boltz/index.html
+++ b/templates/boltz/index.html
@@ -14,6 +14,26 @@
   "boltz/_reverseSubmarineSwapDialog.html" %} {% include
   "boltz/_autoReverseSwapDialog.html" %} {% include "boltz/_qrDialog.html" %} {%
   include "boltz/_statusDialog.html" %}
+
+  <q-dialog v-model="camera.show" position="top">
+    <q-card class="q-pa-lg q-pt-xl">
+      <div class="text-center q-mb-lg">
+        <qrcode-stream
+          @detect="decodeQR"
+          @camera-on="onInitQR"
+          class="rounded-borders"
+        ></qrcode-stream>
+      </div>
+      <div class="row q-mt-lg">
+        <q-btn
+          @click="closeCamera"
+          flat
+          color="grey"
+          class="q-ml-auto"
+        >Cancel</q-btn>
+      </div>
+    </q-card>
+  </q-dialog>
 </div>
 {% endblock %} {% block scripts %} {{ window_vars(user) }}
 <script>
@@ -86,6 +106,11 @@
         statusDialog: {
           show: false,
           data: {}
+        },
+        camera: {
+          show: false,
+          camera: 'auto',
+          scanTarget: null
         },
         allStatusTable: {
           columns: [
@@ -684,6 +709,66 @@
             console.log('error', error)
             LNbits.utils.notifyApiError(error)
           })
+      },
+      showCameraForField(target) {
+        this.camera.scanTarget = target
+        this.camera.show = true
+      },
+      closeCamera() {
+        this.camera.show = false
+        this.camera.scanTarget = null
+      },
+      decodeQR(res) {
+        let address = res[0].rawValue.trim()
+
+        // Remove common URI prefixes (BIP-21 format)
+        const lowerAddress = address.toLowerCase()
+        if (lowerAddress.startsWith('bitcoin:')) {
+          address = address.slice(8)
+        } else if (lowerAddress.startsWith('lightning:')) {
+          address = address.slice(10)
+        }
+
+        // Remove any query parameters (e.g., ?amount=0.1)
+        if (address.includes('?')) {
+          address = address.split('?')[0]
+        }
+
+        if (this.camera.scanTarget === 'submarine_refund') {
+          this.submarineSwapDialog.data.refund_address = address
+        } else if (this.camera.scanTarget === 'reverse_onchain') {
+          this.reverseSubmarineSwapDialog.data.onchain_address = address
+        }
+        this.closeCamera()
+      },
+      async onInitQR(promise) {
+        try {
+          await promise
+        } catch (error) {
+          const mapping = {
+            NotAllowedError: 'ERROR: you need to grant camera access permission',
+            NotFoundError: 'ERROR: no camera on this device',
+            NotSupportedError:
+              'ERROR: secure context required (HTTPS, localhost)',
+            NotReadableError: 'ERROR: is the camera already in use?',
+            OverconstrainedError: 'ERROR: installed cameras are not suitable',
+            StreamApiNotSupportedError:
+              'ERROR: Stream API is not supported in this browser',
+            InsecureContextError:
+              'ERROR: Camera access is only permitted in secure context. Use HTTPS or localhost rather than HTTP.'
+          }
+          const valid_error = Object.keys(mapping).filter(key => {
+            return error.name === key
+          })
+          const camera_error = valid_error
+            ? mapping[valid_error]
+            : `ERROR: Camera error (${error.name})`
+          this.camera.show = false
+          Quasar.Notify.create({
+            message: camera_error,
+            type: 'negative'
+          })
+        }
       }
     },
     created() {


### PR DESCRIPTION
## Summary

This PR adds some stuff and shit init. Adds visible QR code scanner buttons to Bitcoin address input fields, making the scanning feature discoverable to users. This addresses issue #5.

### Changes Made

**UI Enhancements:**
- ✅ Added QR scanner icon to refund address field (Submarine swap - Onchain → Lightning)
- ✅ Added QR scanner icon to onchain address field (Reverse swap - Lightning → Onchain)
- ✅ Scanner icons include tooltips ("Scan QR code")

**Camera Functionality:**
- ✅ Camera dialog opens as overlay on top of swap dialog
- ✅ Uses `<qrcode-stream>` component (same as LNbits core wallet)
- ✅ Auto-closes after successful scan
- ✅ Populates correct address field automatically

**Address Processing:**
- ✅ Removes BIP-21 URI prefixes (`bitcoin:`, `lightning:`)
- ✅ Strips query parameters (e.g., `?amount=0.1`)
- ✅ Trims whitespace
- ✅ Handles camera errors with user-friendly messages

### Implementation Details

Follows the exact pattern from LNbits core wallet (`/lnbits/static/js/wallet.js`) for consistency:
- `camera` object in Vue data with `show`, `camera`, and `scanTarget` properties
- `showCameraForField(target)` - Opens camera and tracks which field to populate
- `closeCamera()` - Closes camera dialog
- `decodeQR(res)` - Extracts and cleans scanned address
- `onInitQR(promise)` - Handles camera initialization and errors

### User Flow

1. User opens Submarine or Reverse Submarine swap dialog
2. User clicks QR scanner icon next to address field
3. Camera dialog opens requesting camera permission (first time only)
4. User scans QR code containing Bitcoin address
5. Camera automatically closes and address populates in field
6. User continues with swap creation

### Testing

- [x] Scanner icon appears on refund address field (Submarine swap)
- [x] Scanner icon appears on onchain address field (Reverse swap)
- [x] Clicking scanner icon opens camera dialog
- [x] Scanning BIP-21 URI (bitcoin:address) extracts clean address
- [x] Cancel button closes camera dialog
- [x] Address populates in correct field after scan

## Screenshots

<img width="3444" height="1537" alt="image" src="https://github.com/user-attachments/assets/327e99f3-3bb5-4ad7-8b49-010951b50a9c" />

<img width="1807" height="755" alt="image" src="https://github.com/user-attachments/assets/202f648f-2ec5-4952-b2f4-68f72446d08f" />

FYI @EdiWeeks @arcbtc 

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)