### PR TITLE
fix: restore default values in dialog reset methods

### DIFF
--- a/templates/boltz/index.html
+++ b/templates/boltz/index.html
@@ -517,19 +517,33 @@
       resetSubmarineSwapDialog() {
         this.submarineSwapDialog = {
           show: false,
-          data: {}
+          data: {
+            asset: 'BTC/BTC',
+            direction: 'receive',
+            feerate: false
+          }
         }
       },
       resetReverseSubmarineSwapDialog() {
         this.reverseSubmarineSwapDialog = {
           show: false,
-          data: {}
+          data: {
+            asset: 'BTC/BTC',
+            direction: 'send',
+            instant_settlement: true,
+            feerate: false
+          }
         }
       },
       resetAutoReverseSubmarineSwapDialog() {
         this.autoReverseSubmarineSwapDialog = {
           show: false,
-          data: {}
+          data: {
+            asset: 'BTC/BTC',
+            direction: 'send',
+            balance: 100,
+            instant_settlement: true
+          }
         }
       },
       sendReverseSubmarineSwapFormData() {


### PR DESCRIPTION
## Summary
- Fixed validation error "1 validation error for SubmarineSwap feerate none is not an allowed value"
- Updated three reset methods to restore proper default values instead of empty objects
- This ensures subsequent swap creations have valid default values and don't fail Pydantic validation

## Changes
- `resetSubmarineSwapDialog()`: Now restores asset, direction, and feerate
- `resetReverseSubmarineSwapDialog()`: Now restores asset, direction, instant_settlement, and feerate
- `resetAutoReverseSubmarineSwapDialog()`: Now restores asset, direction, balance, and instant_settlement

## Test plan
- [ ] Create an Onchain → LN swap
- [ ] Click Cancel button
- [ ] Try to create another swap
- [ ] Verify no validation error occurs
- [ ] Repeat test with LN → Onchain swap
- [ ] Repeat test with Auto Reverse Swap

**Draft Status:** This PR needs full testing before marking as ready for review.

Fixes #45
Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)