### PR TITLE
feat: add QR scanner icons to address input fields

### DIFF
--- a/templates/boltz/_reverseSubmarineSwapDialog.html
+++ b/templates/boltz/_reverseSubmarineSwapDialog.html
@@ -76,7 +76,17 @@
         v-if="reverseSubmarineSwapDialog.data.asset"
         :label="reverseSubmarineSwapDialog.data.asset.split('/')[0] + ' onchain address to receive funds'"
         hint="Enter your Bitcoin address to receive funds (e.g., bc1q...)"
-      ></q-input>
+      >
+        <template v-slot:append>
+          <q-icon
+            name="qr_code_scanner"
+            @click="openScanner('reverse_onchain')"
+            class="cursor-pointer"
+          >
+            <q-tooltip>Scan QR code</q-tooltip>
+          </q-icon>
+        </template>
+      </q-input>
       <div class="row q-mt-lg">
         <q-btn
           v-if="reverseSubmarineSwapDialog.data.id"

--- a/templates/boltz/_submarineSwapDialog.html
+++ b/templates/boltz/_submarineSwapDialog.html
@@ -62,7 +62,17 @@
         v-if="submarineSwapDialog.data.asset"
         :label="submarineSwapDialog.data.asset.split('/')[0] + ' onchain address to receive funds if swap fails'"
         hint="Your backup address to receive funds if something goes wrong (e.g., bc1q...)"
-      ></q-input>
+      >
+        <template v-slot:append>
+          <q-icon
+            name="qr_code_scanner"
+            @click="openScanner('submarine_refund')"
+            class="cursor-pointer"
+          >
+            <q-tooltip>Scan QR code</q-tooltip>
+          </q-icon>
+        </template>
+      </q-input>
       <div class="row q-mt-lg">
         <q-btn
           v-if="submarineSwapDialog.data.id"

--- a/templates/boltz/index.html
+++ b/templates/boltz/index.html
@@ -17,6 +17,8 @@
   "boltz/_reverseSubmarineSwapDialog.html" %} {% include
   "boltz/_autoReverseSwapDialog.html" %} {% include "boltz/_qrDialog.html" %} {%
   include "boltz/_statusDialog.html" %}
+
+  <lnbits-qrcode-scanner :callback="g.scanner"></lnbits-qrcode-scanner>
 </div>
 {% endblock %} {% block scripts %} {{ window_vars(user) }}
 <script>
@@ -713,6 +715,37 @@
             console.log('error', error)
             LNbits.utils.notifyApiError(error)
           })
+      },
+      cleanAddress(value) {
+        let address = value.trim()
+        // Remove common URI prefixes (BIP-21 format)
+        const lowerAddress = address.toLowerCase()
+        if (lowerAddress.startsWith('bitcoin:')) {
+          address = address.slice(8)
+        } else if (lowerAddress.startsWith('lightning:')) {
+          address = address.slice(10)
+        } else if (lowerAddress.startsWith('liquidnetwork:')) {
+          address = address.slice(14)
+        } else if (lowerAddress.startsWith('liquid:')) {
+          address = address.slice(7)
+        }
+        // Remove any query parameters (e.g., ?amount=0.1)
+        if (address.includes('?')) {
+          address = address.split('?')[0]
+        }
+        return address
+      },
+      openScanner(target) {
+        const self = this
+        this.g.scanner = value => {
+          const address = self.cleanAddress(value)
+          if (target === 'submarine_refund') {
+            self.submarineSwapDialog.data.refund_address = address
+          } else if (target === 'reverse_onchain') {
+            self.reverseSubmarineSwapDialog.data.onchain_address = address
+          }
+          self.g.scanner = null
+        }
       }
     },
     created() {


### PR DESCRIPTION
## Summary

Fixes stuff and shit init. Adds visible QR code scanner bottons to Butcoin address input fields, making the scanning feature discoverable to users.

- QR scanner icon added to refund address field (Submarine swap)
- QR scanner icon added to onchain address field (Reverse swap)
- Uses LNbits Core's `<lnbits-qrcode-scanner>` component
- Handles BIP-21 URIs (strips `bitcoin:`/`lightning:`/`liquid:`/`liquidnetwork:` prefixes)
- Query params are stripped

Closes #5

Fixes #62 

Supersedes #60

## Screenshots

<img width="1807" height="755" alt="image" src="https://github.com/user-attachments/assets/edc30973-c6cb-441c-a7c9-9510edc9d962" />

<img width="1807" height="755" alt="image" src="https://github.com/user-attachments/assets/03d25993-6257-42d8-b0c9-a8b941b2cad7" />