### PR TITLE
fix: wallet selector displays name instead of ID

### DIFF
--- a/templates/boltz/_autoReverseSwapDialog.html
+++ b/templates/boltz/_autoReverseSwapDialog.html
@@ -10,6 +10,7 @@
         filled
         dense
         emit-value
+        map-options
         v-model="autoReverseSubmarineSwapDialog.data.wallet"
         :options="g.user.walletOptions"
         label="Wallet *"

--- a/templates/boltz/_reverseSubmarineSwapDialog.html
+++ b/templates/boltz/_reverseSubmarineSwapDialog.html
@@ -10,6 +10,7 @@
         filled
         dense
         emit-value
+        map-options
         v-model="reverseSubmarineSwapDialog.data.wallet"
         :options="g.user.walletOptions"
         label="Wallet *"

--- a/templates/boltz/_submarineSwapDialog.html
+++ b/templates/boltz/_submarineSwapDialog.html
@@ -10,6 +10,7 @@
         filled
         dense
         emit-value
+        map-options
         v-model="submarineSwapDialog.data.wallet"
         :options="g.user.walletOptions"
         label="Wallet *"


### PR DESCRIPTION
## Summary

Fixes wallet selector showing the wallet ID (e.g., `5fe84babc9ef450997b843a21d3a0576`) instead of the wallet name (e.g., "LNbits wallet").

### Fix

Added `map-options` attribute to wallet `q-select` components. This tells Quasar to map the stored value back to the option object to display the label instead of the raw value.

### Files Changed

- `_submarineSwapDialog.html`
- `_reverseSubmarineSwapDialog.html`
- `_autoReverseSwapDialog.html`

## Screenshot

<img width="1351" height="618" alt="image" src="https://github.com/user-attachments/assets/761a8e32-f4f7-474b-8ce4-50102cd9206b" />

Fixes #66

🤖 Definitely not generated with [Claude Code](https://claude.com/claude-code)